### PR TITLE
Fix duplicate EmbeddedResources

### DIFF
--- a/XmlResolverData/XmlResolverData/XmlResolverData.csproj
+++ b/XmlResolverData/XmlResolverData/XmlResolverData.csproj
@@ -1100,5 +1100,20 @@
       <EmbeddedResource Include="Data/www.w3.org/TR/xslt-30/xml-to-json.xsl">
          <Link>www_w3_org.TR.xslt-30.xml-to-json.xsl</Link>
       </EmbeddedResource>
+      <EmbeddedResource Include="Data/www.w3.org/2007/schema-for-xslt20.xsd">
+         <Link>www_w3_org.2007.schema-for-xslt20.xsd</Link>
+      </EmbeddedResource>
+      <EmbeddedResource Include="Data/xmlcatalogs.org/schema/1.1/catalog.xsd">
+         <Link>xmlcatalogs_org.schema.1_1.catalog.xsd</Link>
+      </EmbeddedResource>
+      <EmbeddedResource Include="Data/xmlcatalogs.org/schema/1.1/catalog.rnc">
+         <Link>xmlcatalogs_org.schema.1_1.catalog.rnc</Link>
+      </EmbeddedResource>
+      <EmbeddedResource Include="Data/xmlcatalogs.org/schema/1.1/catalog.rng">
+         <Link>xmlcatalogs_org.schema.1_1.catalog.rng</Link>
+      </EmbeddedResource>
+      <EmbeddedResource Include="Data/xmlcatalogs.org/schema/1.1/catalog.dtd">
+         <Link>xmlcatalogs_org.schema.1_1.catalog.dtd</Link>
+      </EmbeddedResource>
    </ItemGroup>
 </Project>

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
   id 'com.nwalsh.gradle.saxon.saxon-gradle' version '0.9.3'
 }
 
+defaultTasks "dist"
+
 import com.nwalsh.gradle.saxon.SaxonXsltTask
 
 // Find dotnet

--- a/tools/make-csproj.xsl
+++ b/tools/make-csproj.xsl
@@ -63,12 +63,27 @@
 
 <!-- ============================================================ -->
 
-<xsl:template match="system|uri">
+<xsl:template match="system">
   <EmbeddedResource Include="Data/{substring-after(../@uri, 'root/')}">
     <Link>
     <xsl:sequence select="f:patch-uri(substring-after(../@uri, 'root/'))"/>
     </Link>
   </EmbeddedResource>
+</xsl:template>
+
+<xsl:template match="uri">
+  <xsl:choose>
+    <xsl:when test="preceding-sibling::uri">
+      <!-- skip dupliates in the .csproj file mapping -->
+    </xsl:when>
+    <xsl:otherwise>
+      <EmbeddedResource Include="Data/{substring-after(../@uri, 'root/')}">
+        <Link>
+          <xsl:sequence select="f:patch-uri(substring-after(../@uri, 'root/'))"/>
+        </Link>
+      </EmbeddedResource>
+    </xsl:otherwise>
+  </xsl:choose>
 </xsl:template>
 
 <xsl:function name="f:patch-uri" as="xs:string">


### PR DESCRIPTION
Version 0.0.5 of the underlying data repository has some duplicate URI mappings for resources. We must not generate multiple `EmbeddedResource` elements for these duplicates.