### PR TITLE
Bump the version to 1.2.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-dataVersion=1.2.1
+dataVersion=1.2.3


### PR DESCRIPTION
I accidentally tagged 1.2.2 with the property file set to 1.2.1. This pushes 1.2.3 to restore consistency.